### PR TITLE
file extensions correctly renamed in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,12 +74,12 @@ Conversion
     >>> convert(12, from_unit='XRB', to_unit='raw')
     Decimal('1.2E+31')
 
-    >>> converter(0.4, from_unit='krai', to_unit='XRB')
+    >>> convert(0.4, from_unit='krai', to_unit='XRB')
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
     ValueError: float values can lead to unexpected
     precision loss, please use a Decimal or string
-    eg. converter('0.4', 'krai', 'XRB')
+    eg. convert('0.4', 'krai', 'XRB')
 
     >>> convert('0.4', from_unit='krai', to_unit='XRB')
     Decimal('0.0004')

--- a/README.rst
+++ b/README.rst
@@ -119,7 +119,7 @@ Setup
 
     virtualenv venv
     source venv/bin/activate
-    pip install -r requirements.txt -r test-requirements.txt
+    pip install -r requirements.pip -r test-requirements.pip
     python setup.py develop
 
 Running tests


### PR DESCRIPTION
Just renamed requirements files' extension in the README. 